### PR TITLE
Cleanup, alter TOML configs

### DIFF
--- a/canto.service
+++ b/canto.service
@@ -4,12 +4,12 @@ After=network-online.target
 
 [Service]
 User=USER
-ExecStart=/home/USER/go/bin/cosmovisor start
+ExecStart=/home/INSERT_YOUR_USERNAME_HERE/go/bin/cantod start
 Restart=always
 RestartSec=3
 LimitNOFILE=4096
 Environment="DAEMON_NAME=cantod"
-Environment="DAEMON_HOME=/home/USER/.cantod"
+Environment="DAEMON_HOME=/home/INSERT_YOUR_USERNAME_HERE/.cantod"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 Environment="UNSAFE_SKIP_BACKUP=true"

--- a/setup.sh
+++ b/setup.sh
@@ -2,9 +2,16 @@
 
 set -e
 
-# Add your moniker here
 MONIKER="YOUR_MONIKER_HERE"
+ENABLE_CORS="true"
 
+ENABLE_REST_API="true"
+REST_API_PORT="1317"
+
+PUBLIC_RPC="true"
+RPC_PORT="26657"
+
+# === Don't change anything below this line ===
 # Checks to see if you've already installed Canto
 # 
 [ -e /$HOME/Canto ] && rm -rf /$HOME/Canto
@@ -34,6 +41,20 @@ sed -i 's/seeds = ""/seeds = "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.pol
 
 # Sets service file
 sudo cp $HOME/canto-node-primer/canto.service /etc/systemd/system/
+
+# Config Files
+if [ "$ENABLE_CORS" = "true" ]; then
+  sed -i 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["\*"\]/g' /$HOME/.cantod/config/config.toml
+fi
+
+if [ "$ENABLE_REST_API" = "true" ]; then
+  sed -i 's/enable = false/enable = true/g' /$HOME/.cantod/config/app.toml
+  sed -i 's/address = "tcp:\/\/0.0.0.0:1317"/address = "tcp:\/\/0.0.0.0:'$REST_API_PORT'"/g' /$HOME/.cantod/config/app.toml
+fi
+
+if [ "$PUBLIC_RPC" = "true" ]; then
+  sed -i 's/laddr = "tcp:\/\/127.0.0.1:26657"/c\laddr = "tcp:\/\/0.0.0.0:'$RPC_PORT'"/g' $HOME_DIR/config/config.toml
+fi
 
 # Syncs node
 cd $HOME/canto-node-primer


### PR DESCRIPTION
Removes cosmovisor since it does not have instructions for that, calls cantod directly

updats service file to INSERT_YOUR_USERNAME_HERE

ENABLE_CORS, ENABLE_REST_API and PUBLIC_RPC settings

Sadly neither state sync nor full node restore has worked for me yet due to: https://pastebin.com/zcSkqsep
then: `Error: maximum number of retries exceeded, last error: rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference`

Will check it out tomorrow